### PR TITLE
BUGFIX: bpbbpst_support_statistics() causing out of memory error

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1039,23 +1039,13 @@ function bpbbpst_checklist_moderators( $forum_id = false ) {
  */
 function bpbbpst_support_statistics( $args = '' ) {
 
-	$defaults = array(
-		'post_type'      => bbp_get_topic_post_type(),
-		'posts_per_page' => -1,
-		'meta_query'     => array(
-			array(
-				'key' => '_bpbbpst_support_topic',
-				'value' => 1,
-				'type' => 'numeric',
-				'compare' => '>='
-			)
-		)
-	);
-
-	$r = bbp_parse_args( $args, $defaults, 'support_statistics' );
-
-	$support_query = new WP_Query( $r );
-	$total_support = $support_query->found_posts;
+    global $wpdb;
+    $query = $wpdb->prepare(
+            "SELECT COUNT(meta_value) FROM `wp_postmeta` WHERE `meta_key` = %s AND `meta_value` = %d",
+            '_bpbbpst_support_topic',
+            1
+    );
+    $total_support = $wpdb->get_var($query);
 
 	$all_status = bpbbpst_get_support_status();
 	unset( $all_status['topic-not-support'] );


### PR DESCRIPTION
In some cases where you have a lot of support posts, this code will cause a out of memory error.
The reason being that the code pulls out all support posts and creates Wp_Post objects of them.
This fix changes the code so the total count is fetched in a sub query and so the looping of support posts are done by taking 100 posts at a time, this way PHP does not run out of memory.